### PR TITLE
Add CI/CD pipeline to create a release with artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,30 +1,14 @@
 name: Release
 
-on:
-  workflow_dispatch:
-    inputs:
-      release_type:
-        description: 'Release Type'
-        required: true
-        type: choice
-        default: "Alpha"
-        options:
-          - "Production"
-          - "Alpha"
-      version_override:
-        description: 'Version Override'
-        required: false
-        type: string
-        default: ""
-
 # Recommended permissions, see also:
 # - https://github.com/actions/setup-go?tab=readme-ov-file#recommended-permissions
-#
-# It is set to write to also allow us to create a release.
 
 permissions:
-  contents: write 
+  contents: read
 
+on:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:
@@ -77,35 +61,3 @@ jobs:
         with:
           name: faf-pioneer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
           path: faf-pioneer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.EXT }}
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Set Version
-        id: set_version
-        run: |
-          if [[ -n "${{ github.event.inputs.version_override }}" ]]; then
-            echo "VERSION=${{ github.event.inputs.version_override }}" >> $GITHUB_ENV
-          else
-            echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
-          fi
-
-      - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ env.VERSION }}
-          name: "Release ${{ env.VERSION }}"
-          draft: true
-          generateReleaseNotes: true
-          prerelease: ${{ github.event.inputs.release_type == 'Alpha' }}
-          artifacts: "artifacts/*/*"
-          artifactErrorsFailBuild: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Build
 
 # Recommended permissions, see also:
 # - https://github.com/actions/setup-go?tab=readme-ov-file#recommended-permissions

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,9 +19,12 @@ on:
 
 # Recommended permissions, see also:
 # - https://github.com/actions/setup-go?tab=readme-ov-file#recommended-permissions
+#
+# It is set to write to also allow us to create a release.
 
 permissions:
-  contents: read 
+  contents: write 
+
 
 jobs:
   build:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,8 +22,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      # We need full git history so that the build process can embed it
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release Type'
+        required: true
+        type: choice
+        default: "Alpha"
+        options:
+          - "Production"
+          - "Alpha"
+      version_override:
+        description: 'Version Override'
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Download Dependencies
+        run: go mod tidy
+
+      - name: Run Cross-Compile Script
+        run: chmod +x cross-compile.sh && ./cross-compile.sh
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            faf-pioneer-linux-amd64
+            faf-pioneer-darwin-arm64
+            faf-pioneer-windows-x64
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Set Version
+        id: set_version
+        run: |
+          if [[ -n "${{ github.event.inputs.version_override }}" ]]; then
+            echo "VERSION=${{ github.event.inputs.version_override }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
+          fi
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ env.VERSION }}
+          name: "Release ${{ env.VERSION }}"
+          body: "Release of version ${{ env.VERSION }} (${{ github.event.inputs.release_type }})"
+          draft: true
+          prerelease: ${{ github.event.inputs.release_type == 'Alpha' }}
+          artifacts: "artifacts/*/*"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -44,10 +44,10 @@ jobs:
             EXT: ""
 
     steps:
-      # We need full git history so that the build process can embed it
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
+          # We need full git history so that the build process can embed it
           fetch-depth: 0
 
       - name: Set up Go

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -53,14 +53,21 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
+          # Flag to enable caching of dependencies
+          cache: true
+
+          # Use the same version of Go as defined by the project
+          go-version-file: go.mod
+
+          # Target architecture that we want to compile to
+          architecture: ${{ matrix.GOARCH }}
 
       - name: Download Dependencies
         run: go mod tidy
 
       - name: Build Binary
         run: |
-          GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} go build -o faf-pioneer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.EXT }}
+          GOOS=${{ matrix.GOOS }} go build -o faf-pioneer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.EXT }}
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,6 +17,12 @@ on:
         type: string
         default: ""
 
+# Recommended permissions, see also:
+# - https://github.com/actions/setup-go?tab=readme-ov-file#recommended-permissions
+
+permissions:
+  contents: read 
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,9 +20,24 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            GOOS: linux
+            GOARCH: amd64
+            EXT: ""
+          - os: windows-latest
+            GOOS: windows
+            GOARCH: amd64
+            EXT: ".exe"
+          - os: macos-latest
+            GOOS: darwin
+            GOARCH: amd64
+            EXT: ""
 
     steps:
-
       # We need full git history so that the build process can embed it
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -34,20 +49,15 @@ jobs:
         with:
           go-version: stable
 
-      - name: Download Dependencies
-        run: go mod tidy
+      - name: Build Binary
+        run: |
+          GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} go build -o faf-pioneer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.EXT }}
 
-      - name: Run Cross-Compile Script
-        run: chmod +x cross-compile.sh && ./cross-compile.sh
-
-      - name: Upload Artifacts
+      - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: build-artifacts
-          path: |
-            faf-pioneer-linux-amd64
-            faf-pioneer-darwin-arm64
-            faf-pioneer-windows-x64
+          name: faf-pioneer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+          path: faf-pioneer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.EXT }}
 
   release:
     needs: build

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -49,6 +49,9 @@ jobs:
         with:
           go-version: stable
 
+      - name: Download Dependencies
+        run: go mod tidy
+
       - name: Build Binary
         run: |
           GOOS=${{ matrix.GOOS }} GOARCH=${{ matrix.GOARCH }} go build -o faf-pioneer-${{ matrix.GOOS }}-${{ matrix.GOARCH }}${{ matrix.EXT }}

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -101,7 +101,8 @@ jobs:
         with:
           tag: ${{ env.VERSION }}
           name: "Release ${{ env.VERSION }}"
-          body: "Release of version ${{ env.VERSION }} (${{ github.event.inputs.release_type }})"
           draft: true
+          generateReleaseNotes: true
           prerelease: ${{ github.event.inputs.release_type == 'Alpha' }}
           artifacts: "artifacts/*/*"
+          artifactErrorsFailBuild: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release Type"
+        required: true
+        type: choice
+        default: "Alpha"
+        options:
+          - "Production"
+          - "Alpha"
+      version_override:
+        description: "Version Override"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  # It is set to write to also allow us to create a release.
+  contents: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Set Version
+        id: set_version
+        run: |
+          if [[ -n "${{ github.event.inputs.version_override }}" ]]; then
+            echo "VERSION=${{ github.event.inputs.version_override }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=$(git describe --tags --always)" >> $GITHUB_ENV
+          fi
+
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ env.VERSION }}
+          name: "Release ${{ env.VERSION }}"
+          draft: true
+          generateReleaseNotes: true
+          prerelease: ${{ github.event.inputs.release_type == 'Alpha' }}
+          artifacts: "artifacts/*/*"
+          artifactErrorsFailBuild: true


### PR DESCRIPTION
Closes https://github.com/FAForever/faf-pioneer/issues/11.

Introduces two new workflows. The responsibility of the build workflow is to create the artifacts for the different operating systems. The responsibility of the release workflow is to create a release and expose the artifacts.

As an example of the output:

- https://github.com/Garanas/faf-pioneer/releases

I noticed the existence of `cross-compile.sh`, but it kept erroring out in the workflow. I think it was unable to find the git information to embed. I'm not sure why. The current approach works too.

Recommend to squash this pull request instead of merge and/or rebase. There are some commits that just pollute the history of the main branch.