### PR TITLE
Updated remote logger with ICE-Breaker endpoint

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -44,16 +44,15 @@ func New(ctx context.Context, cancel context.CancelFunc, info *launcher.Info) *A
 	return instance
 }
 
+func (a *Adapter) WriteLogEntryToRemote(entries []*applog.LogEntry) error {
+	return a.icebreakerClient.WriteLogEntryToRemote(entries)
+}
+
 func (a *Adapter) Start() error {
 	// Gather ICE servers and listen for WebRTC events.
 	sessionGameResponse, err := a.icebreakerClient.GetGameSession()
 	if err != nil {
 		return fmt.Errorf("could not query turn servers: %v", err)
-	}
-
-	// If we agreed to share adapter logs, set the remote log sender for logging.
-	if a.launcherInfo.ConsentLogSharing {
-		applog.SetRemoteLogSender(a.icebreakerClient)
 	}
 
 	// Start listening for ICE-Breaker events (SSE - server side event),

--- a/applog/remote_sink.go
+++ b/applog/remote_sink.go
@@ -87,6 +87,7 @@ func (rs *remoteSink) flush() {
 
 	err := rs.sender.WriteLogEntryToRemote(rs.batch)
 	if err != nil {
+		NoRemote().Debug("Failed to flush remoteSink", zap.Error(err))
 		return
 	}
 
@@ -96,11 +97,13 @@ func (rs *remoteSink) flush() {
 
 func (rs *remoteSink) Shutdown(timeout time.Duration) {
 	close(rs.quit)
+
 	done := make(chan struct{})
 	go func() {
 		rs.wg.Wait()
 		close(done)
 	}()
+
 	select {
 	case <-done:
 	case <-time.After(timeout):

--- a/cmd/faf-adapter/main.go
+++ b/cmd/faf-adapter/main.go
@@ -21,14 +21,21 @@ func main() {
 	defer util.WrapAppContextCancelExitMessage(ctx, "Adapter")
 
 	if err := info.Validate(); err != nil {
-		applog.Fatal("Failed to validate command line arguments", zap.Error(err))
+		applog.Error("Failed to validate command line arguments", zap.Error(err))
 		return
+	}
+
+	adapterInstance := adapter.New(ctx, cancel, info)
+
+	// If we agreed to share adapter logs, set the remote log sender for logging.
+	if info.ConsentLogSharing {
+		applog.NoRemote().Info("Log sharing are enabled")
+		applog.SetRemoteLogSender(adapterInstance)
 	}
 
 	applog.LogStartupInfo(info)
 
-	adapterInstance := adapter.New(ctx, cancel, info)
 	if err := adapterInstance.Start(); err != nil {
-		applog.Fatal("Failed to start adapter", zap.Error(err))
+		applog.Error("Failed to start adapter", zap.Error(err))
 	}
 }

--- a/cmd/faf-launcher-emulator/main.go
+++ b/cmd/faf-launcher-emulator/main.go
@@ -78,8 +78,12 @@ func main() {
 	// - For Host (UserA) type in faf-launcher-emulator a command:
 	//   > `connect_to UserB 2 <gameToWebrtcPort of UserB>`
 
-	// join_to UserA 1 62339
-	// connect_to UserB 2 55893
+	// join_to UserA 1 51547
+	// connect_to UserB 2 50569
+
+	// 1234
+	// chat test
+	// message from UserA!
 
 	for scanner.Scan() {
 		value := scanner.Text()

--- a/cmd/faf-net-analyzer/main.go
+++ b/cmd/faf-net-analyzer/main.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"bufio"
+	"encoding/hex"
+	"fmt"
+	"github.com/klauspost/compress/flate"
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type PacketInfo struct {
+	Seq    int
+	Length int
+}
+
+func extractPayloadAndSeq(line string) (payloadHex string, seq string, err error) {
+	parts := strings.Split(line, "|")
+	if len(parts) < 5 {
+		return "", "", fmt.Errorf("not enought fields in packet dump row")
+	}
+	payloadHex = strings.TrimSpace(parts[len(parts)-1])
+	seq = strings.TrimSpace(parts[3])
+	return payloadHex, seq, nil
+}
+
+func dataToHex(buffer []byte) string {
+	var parts []string
+	for _, b := range buffer {
+		parts = append(parts, fmt.Sprintf("%02X", b))
+	}
+	return strings.Join(parts, " ")
+}
+
+type OutputBlock struct {
+	Data       []byte
+	ReceivedAt time.Time
+}
+
+func readerGoroutine(r io.Reader, outCh chan<- OutputBlock) {
+	buf := make([]byte, 4096)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			block := make([]byte, n)
+			copy(block, buf[:n])
+			outCh <- OutputBlock{Data: block, ReceivedAt: time.Now()}
+		}
+		if err != nil {
+			if err != io.EOF {
+				log.Printf("Error reading data from deflate: %v", err)
+			}
+			close(outCh)
+			return
+		}
+	}
+}
+
+func main() {
+	file, err := os.Open("G:\\projects\\faf-pioneer\\packets_2025_03_26-23_05_50.log")
+	if err != nil {
+		log.Fatalf("unable to open a file: %v", err)
+	}
+	defer func(file *os.File) {
+		_ = file.Close()
+	}(file)
+
+	scanner := bufio.NewScanner(file)
+	lineCount := 0
+	// Skip first 3 lines of file header.
+	for scanner.Scan() {
+		lineCount++
+		if lineCount >= 3 {
+			break
+		}
+	}
+
+	// Pipe for data transfer to deflate.
+	pr, pw := io.Pipe()
+
+	// Game uses `flate` from zlib using 1 << 14 window size, but for `deflate`
+	// this doesn't really matter, so just create default `flate` reader.
+	// One important thing there is that game also didn't include zlib flate header bytes, only
+	// processing raw packets payload into GPGNetStream data.
+
+	deflateReader := flate.NewReader(pr)
+	defer func(deflateReader io.ReadCloser) {
+		_ = deflateReader.Close()
+	}(deflateReader)
+
+	outCh := make(chan OutputBlock, 10)
+	go readerGoroutine(deflateReader, outCh)
+
+	var pendingPackets []PacketInfo
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		// Take only incoming `DATA` packets into account.
+		if !strings.HasPrefix(line, " -> | DATA") {
+			continue
+		}
+
+		payloadHex, seqStr, err := extractPayloadAndSeq(line)
+		if err != nil {
+			continue
+		}
+
+		cleanHex := strings.ReplaceAll(payloadHex, " ", "")
+		if cleanHex == "" {
+			continue
+		}
+
+		data, err := hex.DecodeString(cleanHex)
+		if err != nil {
+			log.Printf("Hex decode for row '%q', are failed: %v", payloadHex, err)
+			continue
+		}
+		seq, err := strconv.Atoi(seqStr)
+		if err != nil {
+			log.Printf("Failed to parse packet Seq number: %v", err)
+			continue
+		}
+
+		log.Printf("Data of a DATA packet [Seq = '%d', Size = '%d' (bytes)]", seq, len(data))
+		_, err = pw.Write(data)
+		if err != nil {
+			log.Printf("Failed writing data into pipe: %v", err)
+			break
+		}
+
+		pendingPackets = append(pendingPackets, PacketInfo{Seq: seq, Length: len(data)})
+		// Wait for deflate to process.
+		time.Sleep(100 * time.Millisecond)
+
+		select {
+		case block, ok := <-outCh:
+			if ok {
+				printUsedPacketData(pendingPackets, block)
+				pendingPackets = nil
+			}
+		default:
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		log.Printf("Failed to scan line from input file: %v", err)
+	}
+
+	_ = pw.Close()
+
+	// Output all left packets.
+	for block := range outCh {
+		printUsedPacketData(pendingPackets, block)
+	}
+}
+
+func printUsedPacketData(pendingPackets []PacketInfo, block OutputBlock) {
+	fmt.Printf("\n=== Decompressed (%d bytes) at %v ===\n", len(block.Data), block.ReceivedAt)
+	fmt.Printf("Output data: %s\n", dataToHex(block.Data))
+	fmt.Println("Packets that were used to form a valid decompression sequence:")
+	fmt.Println("+------+----------------------+")
+	fmt.Println("| Seq  | Length (bytes)       |")
+	fmt.Println("+------+----------------------+")
+	for _, p := range pendingPackets {
+		fmt.Printf("| %4d | %20d |\n", p.Seq, p.Length)
+	}
+	fmt.Println("+------+----------------------+")
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       test: wget -S -qO /dev/null http://localhost:3100/ready 2>&1 | awk '/HTTP\/[0-9.]+/ {if ($2 == 200) exit 0; else exit 1} END {if (NR == 0) exit 1}'
 
   faf-icebreaker:
-    image: faforever/faf-icebreaker:1.1.1
+    image: faforever/faf-icebreaker:1.1.2
     ports:
       - "0.0.0.0:8080:8080"
     environment:

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module faf-pioneer
 go 1.24.0
 
 require (
+	github.com/klauspost/compress v1.18.0
 	github.com/pion/webrtc/v4 v4.0.14
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
+github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/gpgnet/cmd_chat.go
+++ b/gpgnet/cmd_chat.go
@@ -1,0 +1,28 @@
+package gpgnet
+
+import "fmt"
+
+type ChatMessage struct {
+	Message string
+}
+
+func (m *ChatMessage) GetCommand() string {
+	return MessageCommandChat
+}
+
+func (m *ChatMessage) GetArgs() []interface{} {
+	return []interface{}{
+		m.Message,
+	}
+}
+
+const chatMessageArgs = 1
+
+func (m *ChatMessage) Build(args []interface{}) (Message, error) {
+	if len(args) < chatMessageArgs {
+		return m, fmt.Errorf("not enough arguments to parse (%d < %d)", len(args), chatMessageArgs)
+	}
+
+	m.Message = args[0].(string)
+	return m, nil
+}

--- a/gpgnet/cmd_game_result.go
+++ b/gpgnet/cmd_game_result.go
@@ -1,0 +1,31 @@
+package gpgnet
+
+import "fmt"
+
+type GameResultMessage struct {
+	TeamId int32
+	Result string
+}
+
+func (m *GameResultMessage) GetCommand() string {
+	return MessageCommandGameResult
+}
+
+func (m *GameResultMessage) GetArgs() []interface{} {
+	return []interface{}{
+		m.TeamId,
+		m.Result,
+	}
+}
+
+const gameResultMessageArgs = 2
+
+func (m *GameResultMessage) Build(args []interface{}) (Message, error) {
+	if len(args) < gameResultMessageArgs {
+		return m, fmt.Errorf("not enough arguments to parse (%d < %d)", len(args), gameResultMessageArgs)
+	}
+
+	m.TeamId = args[0].(int32)
+	m.Result = args[1].(string)
+	return m, nil
+}

--- a/gpgnet/cmd_json_stats.go
+++ b/gpgnet/cmd_json_stats.go
@@ -1,0 +1,75 @@
+package gpgnet
+
+import (
+	"encoding/json"
+	"faf-pioneer/applog"
+	"fmt"
+	"go.uber.org/zap"
+)
+
+type JsonStatsEntryGeneral struct {
+	LastUpdateTick uint64 `json:"lastupdatetick"`
+	Score          uint64 `json:"score"`
+	CurrentCap     uint16 `json:"currentcap"`
+	CurrentUnits   uint16 `json:"currentunits"`
+}
+
+type JsonStatsEntry struct {
+	Type     string                `json:"type"`
+	Name     string                `json:"name"`
+	Faction  int                   `json:"faction"`
+	Defeated float32               `json:"defeated"`
+	General  JsonStatsEntryGeneral `json:"general"`
+}
+
+type JsonStatsData struct {
+	Stats []JsonStatsEntry `json:"stats"`
+}
+
+type JsonStatsMessage struct {
+	Data JsonStatsData
+}
+
+func NewJsonStatsMessage(
+	data JsonStatsData,
+) Message {
+	return &JsonStatsMessage{
+		Data: data,
+	}
+}
+
+func (m *JsonStatsMessage) GetCommand() string {
+	return MessageCommandJsonStats
+}
+
+func (m *JsonStatsMessage) GetArgs() []interface{} {
+	data, err := json.Marshal(m.Data)
+	if err != nil {
+		applog.Error("Failed to marshal JsonStatsMessage", zap.Error(err))
+		return []interface{}{
+			"{}",
+		}
+	}
+
+	return []interface{}{
+		string(data),
+	}
+}
+
+const jsonStatsMessageArgs = 1
+
+func (m *JsonStatsMessage) Build(args []interface{}) (Message, error) {
+	if len(args) < jsonStatsMessageArgs {
+		return m, fmt.Errorf("not enough arguments to parse (%d < %d)", len(args), jsonStatsMessageArgs)
+	}
+
+	m.Data = JsonStatsData{}
+
+	stringData := args[0].(string)
+	err := json.Unmarshal([]byte(stringData), &m.Data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse json stats message: %w", err)
+	}
+
+	return m, nil
+}

--- a/gpgnet/message.go
+++ b/gpgnet/message.go
@@ -18,6 +18,9 @@ const (
 	MessageCommandGameEnded          MessageCommand = "GameEnded"
 	MessageCommandGameFull           MessageCommand = "GameFull"
 	MessageCommandGameOption         MessageCommand = "GameOption"
+	MessageCommandChat               MessageCommand = "Chat"
+	MessageCommandJsonStats          MessageCommand = "JsonStats"
+	MessageCommandGameResult         MessageCommand = "GameResult"
 )
 
 type Message interface {
@@ -66,6 +69,9 @@ var messagesRegistry = map[MessageCommand]messageBuilder{
 	MessageCommandGameEnded:          new(GameEndedMessage).Build,
 	MessageCommandGameFull:           new(GameFullMessage).Build,
 	MessageCommandGameOption:         new(GameOptionMessage).Build,
+	MessageCommandChat:               new(ChatMessage).Build,
+	MessageCommandJsonStats:          new(JsonStatsMessage).Build,
+	MessageCommandGameResult:         new(GameResultMessage).Build,
 }
 
 func (m *BaseMessage) TryParse() (Message, error) {

--- a/icebreaker/api.go
+++ b/icebreaker/api.go
@@ -1,5 +1,10 @@
 package icebreaker
 
+import (
+	"faf-pioneer/applog"
+	"time"
+)
+
 type SessionTokenRequest struct {
 	GameId uint64 `json:"gameId"`
 }
@@ -18,4 +23,40 @@ type SessionGameResponseServer struct {
 	Username   string   `json:"username,omitempty"`
 	Credential string   `json:"credential,omitempty"`
 	Urls       []string `json:"urls"`
+}
+
+type LogsMessageRequest struct {
+	Timestamp time.Time              `json:"timestamp"`
+	Message   string                 `json:"message"`
+	MetaData  map[string]interface{} `json:"metaData"`
+}
+
+// NewLogMessagesFromAppLogEntries is to convert our application log entries wrapper (applog.LogEntry)
+// that contains log messages and fields (zap.Entry).
+func NewLogMessagesFromAppLogEntries(entries []*applog.LogEntry) []LogsMessageRequest {
+	ret := make([]LogsMessageRequest, 0, len(entries))
+
+	for _, entry := range entries {
+		requestEntry := LogsMessageRequest{
+			Timestamp: entry.Entry.Time,
+			Message:   entry.Entry.Message,
+			MetaData: map[string]interface{}{
+				"level":  entry.Entry.Level.String(),
+				"caller": entry.Entry.Caller.String(),
+			},
+		}
+
+		for _, field := range entry.Fields {
+			data, err := applog.ExtractFieldValue(field)
+			if err != nil {
+				continue
+			}
+
+			requestEntry.MetaData[field.Key] = data
+		}
+
+		ret = append(ret, requestEntry)
+	}
+
+	return ret
 }

--- a/util/common.go
+++ b/util/common.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"go.uber.org/zap"
 	"net"
+	"strconv"
 	"strings"
 )
 
@@ -33,6 +34,19 @@ func DataToHex(buffer []byte) string {
 		parts = append(parts, fmt.Sprintf("%02X", b))
 	}
 	return strings.Join(parts, " ")
+}
+
+func HexStrToData(hexStr string) []byte {
+	parts := strings.Split(hexStr, " ")
+	data := make([]byte, len(parts))
+	for i, part := range parts {
+		b, err := strconv.ParseUint(part, 16, 8)
+		if err != nil {
+			return nil
+		}
+		data[i] = byte(b)
+	}
+	return data
 }
 
 type DumpDirection = uint8
@@ -75,7 +89,8 @@ func DumpPacket(buffer []byte, addr *net.UDPAddr, msg string, dir DumpDirection)
 			zap.Uint16("ackSeq", data.Header.AckSequence),
 			zap.Uint32("type", data.Header.Type),
 			zap.Uint16("payloadLength", data.Header.PayloadLength),
-			zap.String("extraHeader", DataToHex(data.Header.Extra[:])),
+			zap.Uint16("simBeat", data.Header.SimBeat),
+			zap.Uint16("remoteSimBeat", data.Header.RemoteSimBeat),
 			zap.String("payload", DataToHex(data.Payload)),
 		)...)
 }

--- a/util/context.go
+++ b/util/context.go
@@ -1,0 +1,50 @@
+package util
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type ContextJob struct {
+	jobDone chan struct{}
+	ctx     context.Context
+	cancel  context.CancelFunc
+	once    sync.Once
+}
+
+func (cj *ContextJob) Done() {
+	cj.once.Do(func() {
+		close(cj.jobDone)
+	})
+}
+
+func (cj *ContextJob) GetContext() context.Context {
+	return cj.ctx
+}
+
+func DelayedCancelContextWithJob(
+	parent context.Context,
+	maxDelay time.Duration,
+) *ContextJob {
+	jobDone := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		// Wait for parent context to be canceled.
+		<-parent.Done()
+		// Now either wait for job finish using a channel signaling,
+		// or just timeout after max delay duration.
+		select {
+		case <-jobDone:
+			cancel()
+		case <-time.After(maxDelay):
+			cancel()
+		}
+	}()
+
+	return &ContextJob{
+		ctx:     ctx,
+		cancel:  cancel,
+		jobDone: jobDone,
+	}
+}

--- a/util/packet_logger.go
+++ b/util/packet_logger.go
@@ -1,0 +1,88 @@
+package util
+
+import (
+	"faf-pioneer/gpgnet"
+	"fmt"
+	"os"
+	"sync"
+)
+
+type PacketLogger struct {
+	file *os.File
+	mu   sync.Mutex
+}
+
+func NewPacketLogger(filename string) (*PacketLogger, error) {
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	header := "" +
+		"----+-----------+----+-------+-------+-------+-------+-------+-----------\n" +
+		"Dir | Type      | ?? | Seq   | AckSq | LSimB | RSimB | PaLen | Payload   \n" +
+		"----+-----------+----+-------+-------+-------+-------+-------+-----------\n"
+
+	if _, err = file.WriteString(header); err != nil {
+		return nil, err
+	}
+
+	return &PacketLogger{file: file}, nil
+}
+
+func (pl *PacketLogger) LogPacket(direction string, data []byte) error {
+	packet, err := gpgnet.ParseGamePacket(data)
+	if err != nil {
+		return fmt.Errorf("failed to parse packet: %w", err)
+	}
+
+	payloadStr := DataToHex(packet.Payload)
+
+	// Generate by template:
+	// dir | Type      | ?? | Seq   | AckSq | LSimB | RSimB | PLen  | Payload
+	line := fmt.Sprintf("%3s | %-9s | %02X | %-5d | %-5d | %-5d | %-5d | %-5d | %s\n",
+		direction,
+		packetTypeToString(packet.Header.Type),
+		packet.Header.UnknownFlag,
+		packet.Header.Sequence,
+		packet.Header.AckSequence,
+		packet.Header.SimBeat,
+		packet.Header.RemoteSimBeat,
+		packet.Header.PayloadLength,
+		payloadStr,
+	)
+
+	pl.mu.Lock()
+	defer pl.mu.Unlock()
+	_, err = pl.file.WriteString(line)
+	return err
+}
+
+func packetTypeToString(packetType gpgnet.PacketType) string {
+	switch packetType {
+	case gpgnet.PacketTypeConnect:
+		return "CONNECT"
+	case gpgnet.PacketTypeAnswer:
+		return "ANSWER"
+	case gpgnet.PacketTypeResetSerial:
+		return "RST-SER"
+	case gpgnet.PacketTypeSerialReset:
+		return "SER-RST"
+	case gpgnet.PacketTypeData:
+		return "DATA"
+	case gpgnet.PacketTypeAck:
+		return "ACK"
+	case gpgnet.PacketTypeKeepalive:
+		return "KEEPALIVE"
+	case gpgnet.PacketTypeGoodbye:
+		return "GOODBYE"
+	case gpgnet.PacketTypeNatTraversal:
+		return "NAT-TRVL"
+	default:
+		return fmt.Sprintf("%02X %02X %02X %02X",
+			uint8(packetType),
+			uint8(packetType>>8),
+			uint8(packetType>>16),
+			uint8(packetType>>24))
+	}
+}


### PR DESCRIPTION
Changes:
- Updated comments.
- Added `noRemoteLogger = zap.New(aggregation, opts...)` because we had missing **caller** option for `NoRemote()` log messages.
- Changed `SetRemoteLogSender` call so that Adapter implements that and we can set remote log sender early as possible, before we will log anything to logger. Otherwise it will skip logging application details as initialization were done only in `adapter.Start()` call.
- Removed `applog.Fatal` and replaced with `applog.Error` as current implementation of Fatal will immediately exit application without giving time for loggers to flush and sync, so no log entries will be added within `applog.Fatal` and even some of them before, if there were in `asyncLogger` queue.
- Replaced direct `zapcore.CheckedEntry` pass with creating a copy of that object in `logToRemoteSink`, because reference will be lost during `asyncLogger.process` call and we will be getting weird messages (duplicated latest log entries actually).
- Added advanced packet logger for debugging network protocol and investigating gpgnet internals as well as packet analyzer so we can decompress UDP packet stream and had more information about what's going on and how it works.
- Added more gpgnet commands like: `Chat`, `JsonStats` and `GameResult`.

Closes https://github.com/FAForever/faf-pioneer/issues/10 and https://github.com/FAForever/faf-pioneer/issues/7