### PR TITLE
Handle other peers disconnection gracefully with Icebreaker

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -121,6 +121,7 @@ func (a *Adapter) Start() error {
 		gameUdpPort,
 		turnServer,
 		iceBreakerEventChannel,
+		a.gpgNetToGame,
 	)
 
 	// Initialize GPG-Net control plane server (connects to FAF.exe) and client (connects to FAF-Client).

--- a/cmd/faf-launcher-emulator/main.go
+++ b/cmd/faf-launcher-emulator/main.go
@@ -27,7 +27,7 @@ func main() {
 	defer util.WrapAppContextCancelExitMessage(ctx, "Launcher-emulator")
 
 	if err := info.Validate(); err != nil {
-		applog.Fatal("Failed to validate command line arguments", zap.Error(err))
+		applog.Error("Failed to validate command line arguments", zap.Error(err))
 		return
 	}
 
@@ -60,7 +60,7 @@ func main() {
 	go func() {
 		err := server.Listen(adapterToFafClient, fafClientToAdapter, adapterConnected)
 		if err != nil {
-			applog.Fatal("Failed to connect to GPG-Net server", zap.Error(err))
+			applog.Error("Failed to connect to GPG-Net server", zap.Error(err))
 		}
 	}()
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -37,7 +37,7 @@ services:
       test: wget -S -qO /dev/null http://localhost:3100/ready 2>&1 | awk '/HTTP\/[0-9.]+/ {if ($2 == 200) exit 0; else exit 1} END {if (NR == 0) exit 1}'
 
   faf-icebreaker:
-    image: faforever/faf-icebreaker:1.1.2
+    image: faforever/faf-icebreaker:1.1.3
     ports:
       - "0.0.0.0:8080:8080"
     environment:

--- a/icebreaker/icebreaker.go
+++ b/icebreaker/icebreaker.go
@@ -214,6 +214,11 @@ func (c *Client) Listen(channel chan EventMessage) error {
 					zap.Any("event", e),
 					zap.String("eventType", e.EventType),
 				)
+			case *PeerClosingMessage:
+				applog.Debug("Handing ICE-Breaker API event",
+					zap.Any("event", e),
+					zap.String("eventType", e.EventType),
+				)
 			default:
 				applog.Debug("Handing unknown ICE-Breaker API event",
 					zap.Any("event", e),


### PR DESCRIPTION
Had to add `gpgNetToGameChannel` into `PeerManager` to send disconnect from peer messages as we are handling IceBreaker events there in `handleIceBreakerEvent`.