### PR TITLE
fix: Ensure log creation errors won't terminate pioneer

### DIFF
--- a/applog/applog.go
+++ b/applog/applog.go
@@ -188,7 +188,7 @@ func Initialize(userId uint, gameId uint64, rawLogLevel int, logPath string) err
 	stdoutCore = zapcore.NewCore(jsonEncoder, zapcore.AddSync(os.Stdout), logLevel)
 
 	stdoutAsync := newAsyncSink(stdoutCore, asyncSinkMaxLogEntriesBufferSize)
-	fileAsync, fileErr := initializeFileLogger(userId, gameId, encoderConfig, logLevel, logPath)
+	fileAsync, fileErr := initializeFileLogger(userId, gameId, jsonEncoder, logLevel, logPath)
 
 	asyncSinks = make([]baseSink, 0, 2)
 	asyncSinks = append(asyncSinks, stdoutAsync)
@@ -213,7 +213,7 @@ func Initialize(userId uint, gameId uint64, rawLogLevel int, logPath string) err
 func initializeFileLogger(
 	userId uint,
 	gameId uint64,
-	encoderConfig zapcore.EncoderConfig,
+	jsonEncoder zapcore.Encoder,
 	logLevel zapcore.Level,
 	logPath string,
 ) (*asyncSink, error) {
@@ -240,7 +240,6 @@ func initializeFileLogger(
 		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
 
-	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
 	fileCore = zapcore.NewCore(jsonEncoder, zapcore.AddSync(logFile), logLevel)
 	fileAsync := newAsyncSink(fileCore, asyncSinkMaxLogEntriesBufferSize)
 

--- a/applog/applog.go
+++ b/applog/applog.go
@@ -180,15 +180,50 @@ func LogStartupInfo(launchArgs interface{}) {
 	)
 }
 
-func Initialize(userId uint, gameId uint64, rawLogLevel int) {
-	workdir, err := os.Getwd()
+func Initialize(userId uint, gameId uint64, rawLogLevel int, logPath string) error {
+	encoderConfig := getEncoderConfig()
+	logLevel := safeGetLogLevelOrDefault(rawLogLevel)
+
+	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
+	stdoutCore = zapcore.NewCore(jsonEncoder, zapcore.AddSync(os.Stdout), logLevel)
+
+	stdoutAsync := newAsyncSink(stdoutCore, asyncSinkMaxLogEntriesBufferSize)
+	fileAsync, fileErr := initializeFileLogger(userId, gameId, encoderConfig, logLevel, logPath)
+
+	asyncSinks = make([]baseSink, 0, 2)
+	asyncSinks = append(asyncSinks, stdoutAsync)
+	cores := make([]zapcore.Core, 0, 2)
+	cores = append(cores, stdoutCore)
+
+	if fileErr == nil {
+		asyncSinks = append(asyncSinks, fileAsync)
+		cores = append(cores, fileAsync)
+	}
+
+	aggCore := zapcore.NewTee(cores...)
+	globalLogger = zap.New(aggCore, opts...).With(
+		zap.Uint("localUserId", userId),
+		zap.Uint64("localGameId", gameId),
+	)
+
+	setLogger(globalLogger)
+	return fileErr
+}
+
+func initializeFileLogger(
+	userId uint,
+	gameId uint64,
+	encoderConfig zapcore.EncoderConfig,
+	logLevel zapcore.Level,
+	logPath string,
+) (*asyncSink, error) {
+	logDir, err := resolveLogPath(logPath)
 	if err != nil {
-		log.Fatalf("Failed to get current working directory: %v", err)
+		return nil, fmt.Errorf("failed to resolve log path '%s': %w", logPath, err)
 	}
 
 	logFilename := filepath.Join(
-		workdir,
-		"logs",
+		logDir,
 		fmt.Sprintf("game_%d_user_%d.log",
 			gameId,
 			userId,
@@ -197,32 +232,42 @@ func Initialize(userId uint, gameId uint64, rawLogLevel int) {
 
 	err = os.MkdirAll(filepath.Dir(logFilename), os.ModePerm)
 	if err != nil {
-		log.Fatalf("Failed to create log directory: %v", err)
+		return nil, fmt.Errorf("failed to create log directory: %w", err)
 	}
 
 	logFile, err = os.OpenFile(logFilename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
-		log.Fatalf("Failed to open log file: %v", err)
+		return nil, fmt.Errorf("failed to open log file: %w", err)
 	}
 
-	encoderConfig := getEncoderConfig()
-	logLevel := safeGetLogLevelOrDefault(rawLogLevel)
-
 	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
-	stdoutCore = zapcore.NewCore(jsonEncoder, zapcore.AddSync(os.Stdout), logLevel)
 	fileCore = zapcore.NewCore(jsonEncoder, zapcore.AddSync(logFile), logLevel)
-
-	stdoutAsync := newAsyncSink(stdoutCore, asyncSinkMaxLogEntriesBufferSize)
 	fileAsync := newAsyncSink(fileCore, asyncSinkMaxLogEntriesBufferSize)
 
-	asyncSinks = []baseSink{stdoutAsync, fileAsync}
+	return fileAsync, nil
+}
 
-	aggCore := zapcore.NewTee(stdoutAsync, fileAsync)
-	globalLogger = zap.New(aggCore, opts...).With(
-		zap.Uint("localUserId", userId),
-		zap.Uint64("localGameId", gameId))
+func resolveLogPath(logPath string) (string, error) {
+	if logPath != "" {
+		info, err := os.Stat(logPath)
+		if err != nil || !info.IsDir() {
+			log.Printf(
+				"Selected log path '%s' does not exist or is not a directory, falling back to working directory\n",
+				logPath,
+			)
+			logPath = ""
+		}
+	}
 
-	setLogger(globalLogger)
+	if logPath == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get current working directory: %w", err)
+		}
+		logPath = filepath.Join(wd, "logs")
+	}
+
+	return logPath, nil
 }
 
 func SetRemoteLogSender(sender RemoteLogSender) {

--- a/applog/applog_test.go
+++ b/applog/applog_test.go
@@ -32,7 +32,8 @@ func TestInitializeCreatesLogFileAndSetsGlobals(t *testing.T) {
 	gameId := uint64(1000)
 	rawLogLevel := int(zapcore.InfoLevel)
 
-	Initialize(userId, gameId, rawLogLevel)
+	err = Initialize(userId, gameId, rawLogLevel, "")
+	assert.NoError(t, err, fmt.Sprintf("could not initialize logger: %v", err))
 
 	if logFile != nil {
 		t.Cleanup(func() {
@@ -73,7 +74,8 @@ func TestInitializeDoesNotFailOnValidDirectory(t *testing.T) {
 	gameId := uint64(1000)
 	rawLogLevel := int(zapcore.DebugLevel)
 
-	Initialize(userId, gameId, rawLogLevel)
+	err = Initialize(userId, gameId, rawLogLevel, "")
+	assert.NoError(t, err, fmt.Sprintf("could not initialize logger: %v", err))
 
 	if logFile != nil {
 		t.Cleanup(func() {

--- a/cmd/faf-adapter/main.go
+++ b/cmd/faf-adapter/main.go
@@ -6,6 +6,7 @@ import (
 	"faf-pioneer/applog"
 	"faf-pioneer/launcher"
 	"faf-pioneer/util"
+	"fmt"
 	"go.uber.org/zap"
 	"os/signal"
 	"syscall"
@@ -16,11 +17,15 @@ func main() {
 	defer cancel()
 
 	info := launcher.NewInfoFromFlags()
-	applog.Initialize(info.UserId, info.GameId, info.LogLevel)
+	err := applog.Initialize(info.UserId, info.GameId, info.LogLevel, info.LogPath)
+	if err != nil {
+		fmt.Printf("Failed to initialize app logger: %v\n", err)
+	}
+
 	defer applog.Shutdown()
 	defer util.WrapAppContextCancelExitMessage(ctx, "Adapter")
 
-	if err := info.Validate(); err != nil {
+	if err = info.Validate(); err != nil {
 		applog.Error("Failed to validate command line arguments", zap.Error(err))
 		return
 	}
@@ -37,7 +42,7 @@ func main() {
 
 	applog.LogStartupInfo(info)
 
-	if err := adapterInstance.Start(); err != nil {
+	if err = adapterInstance.Start(); err != nil {
 		applog.Error("Failed to start adapter", zap.Error(err))
 	}
 }

--- a/cmd/faf-launcher-emulator/main.go
+++ b/cmd/faf-launcher-emulator/main.go
@@ -22,11 +22,15 @@ func main() {
 	defer cancel()
 
 	info := launcher.NewInfoFromFlags()
-	applog.Initialize(info.UserId, info.GameId, info.LogLevel)
+	err := applog.Initialize(info.UserId, info.GameId, info.LogLevel, info.LogPath)
+	if err != nil {
+		fmt.Printf("Failed to initialize app logger: %v\n", err)
+	}
+
 	defer applog.Shutdown()
 	defer util.WrapAppContextCancelExitMessage(ctx, "Launcher-emulator")
 
-	if err := info.Validate(); err != nil {
+	if err = info.Validate(); err != nil {
 		applog.Error("Failed to validate command line arguments", zap.Error(err))
 		return
 	}
@@ -43,7 +47,7 @@ func main() {
 	fafProcess := NewGameProcess(ctx, info)
 
 	adapterConnected := func() {
-		if err := fafProcess.Start(); err != nil {
+		if err = fafProcess.Start(); err != nil {
 			applog.Error("Failed to start game process", zap.Error(err))
 			return
 		}
@@ -58,7 +62,7 @@ func main() {
 	}
 
 	go func() {
-		err := server.Listen(adapterToFafClient, fafClientToAdapter, adapterConnected)
+		err = server.Listen(adapterToFafClient, fafClientToAdapter, adapterConnected)
 		if err != nil {
 			applog.Error("Failed to connect to GPG-Net server", zap.Error(err))
 		}

--- a/launcher/info.go
+++ b/launcher/info.go
@@ -16,6 +16,7 @@ type Info struct {
 	ForceTurnRelay    bool
 	ConsentLogSharing bool
 	LogLevel          int
+	LogPath           string
 }
 
 func NewInfoFromFlags() *Info {
@@ -39,6 +40,10 @@ func NewInfoFromFlags() *Info {
 		"consent-log-sharing", false, "Consent log sharing")
 	logLevel := flag.Int(
 		"log-level", 0, "Log level: -1 - Trace, 0 - Info, 1 - Error, 2/3 - Panic, 4 - Fatal")
+	logPath := flag.String(
+		"log-path",
+		"",
+		"Directory to the logs, otherwise will use working directory and add 'logs' to that path")
 
 	flag.Parse()
 
@@ -53,6 +58,7 @@ func NewInfoFromFlags() *Info {
 		ForceTurnRelay:    *forceTurnRelay,
 		ConsentLogSharing: *consentLogSharing,
 		LogLevel:          *logLevel,
+		LogPath:           *logPath,
 	}
 }
 


### PR DESCRIPTION
Fixes issue https://github.com/FAForever/faf-pioneer/issues/24, if we need we can set `--log-path` argument or it will fallback to working directory (also will use **cwd** when destination directory does not exists).