### PR TITLE
Fix: Use `stdout` asyncSink instead of stdoutCore in NewTee()

### DIFF
--- a/applog/applog.go
+++ b/applog/applog.go
@@ -193,7 +193,7 @@ func Initialize(userId uint, gameId uint64, rawLogLevel int, logPath string) err
 	asyncSinks = make([]baseSink, 0, 2)
 	asyncSinks = append(asyncSinks, stdoutAsync)
 	cores := make([]zapcore.Core, 0, 2)
-	cores = append(cores, stdoutCore)
+	cores = append(cores, stdoutAsync)
 
 	if fileErr == nil {
 		asyncSinks = append(asyncSinks, fileAsync)


### PR DESCRIPTION
Switched from using the synchronous stdoutCore to the asynchronous stdoutAsync for stdout logging.
This change ensures that logging to `stdout` can never block the main application, even if `stdout` is not being read or the buffer is full.
Thanks to **gatsik**, he tested this out and confirmed that patch is working (btw - [original initial message in Discord](https://discord.com/channels/197033481883222026/1116363333277331597/1389366143235653753)).

**P.S.** `stdoutAsync` has all of the functions that required for `zapcore.Core` interface.