### PR TITLE
feat: Add X-HMAC to IceBreaker API calls

### DIFF
--- a/icebreaker/hmac.go
+++ b/icebreaker/hmac.go
@@ -1,0 +1,37 @@
+package icebreaker
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+func extractHMACFromJWT(accessToken string) (string, error) {
+	if accessToken == "" {
+		return "", fmt.Errorf("empty string")
+	}
+
+	parts := strings.Split(accessToken, ".")
+	if len(parts) != 3 {
+		return "", fmt.Errorf("wrong length/format")
+	}
+
+	// Extract payload, JWT usually consists of `<header>.<payload>.<signature>`.
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("failed to decode payload: %w", err)
+	}
+
+	var claims struct {
+		Ext struct {
+			HMAC string `json:"hmac"`
+		} `json:"ext"`
+	}
+
+	if err = json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("failed to unmarshal payload: %w", err)
+	}
+
+	return claims.Ext.HMAC, nil
+}


### PR DESCRIPTION
For issue https://github.com/FAForever/faf-pioneer/issues/26:
- Added `X-HMAC` header to IceBreaker calls.
- Updated `SetAuthToken` to use `sessionToken` everywhere (except `withSessionToken`).