### PR TITLE
fix: Update `JsonStatsMessage` to handle only Raw JSON

### DIFF
--- a/faf/gpgnet_server.go
+++ b/faf/gpgnet_server.go
@@ -308,6 +308,7 @@ func (s *GpgNetServer) ProcessMessage(rawMessage gpgnet.Message) gpgnet.Message 
 		// We have to keep connections still open, otherwise all players get instant disconnect timeout screens for
 		// the other players and can't open their stats
 		applog.FromContext(s.ctx).Info("Game has ended")
+		// s.peerManager.HandleGameEnded()
 		break
 	default:
 		applog.FromContext(s.ctx).Debug(

--- a/gpgnet/cmd_json_stats.go
+++ b/gpgnet/cmd_json_stats.go
@@ -3,23 +3,77 @@ package gpgnet
 import (
 	"encoding/json"
 	"faf-pioneer/applog"
+	"faf-pioneer/util"
 	"fmt"
 	"go.uber.org/zap"
 )
 
+type JsonStatsEntryCounter struct {
+	Mass   float64 `json:"mass"`
+	Count  int64   `json:"count"`
+	Energy float64 `json:"energy"`
+}
+
 type JsonStatsEntryGeneral struct {
-	LastUpdateTick uint64 `json:"lastupdatetick"`
-	Score          uint64 `json:"score"`
-	CurrentCap     uint16 `json:"currentcap"`
-	CurrentUnits   uint16 `json:"currentunits"`
+	LastUpdateTick uint64                `json:"lastupdatetick"`
+	Score          float64               `json:"score"`
+	CurrentCap     float64               `json:"currentcap"`
+	CurrentUnits   float64               `json:"currentunits"`
+	Lost           JsonStatsEntryCounter `json:"lost"`
+	Kills          JsonStatsEntryCounter `json:"kills"`
+	Built          JsonStatsEntryCounter `json:"built"`
+}
+
+type JsonUnitCounters struct {
+	Lost  int64 `json:"lost"`
+	Kills int64 `json:"kills"`
+	Built int64 `json:"built"`
+}
+
+type JsonBlueprintStats struct {
+	Kills        int64   `json:"kills"`
+	Built        int64   `json:"built"`
+	Lost         int64   `json:"lost"`
+	LowestHealth float64 `json:"lowest_health"`
+}
+
+type JsonResourceIn struct {
+	Total       float64 `json:"total"`
+	Reclaimed   float64 `json:"reclaimed,omitempty"`
+	ReclaimRate float64 `json:"reclaimRate,omitempty"`
+	Rate        float64 `json:"rate"`
+}
+
+type JsonResourceOut struct {
+	Total  float64 `json:"total"`
+	Rate   float64 `json:"rate"`
+	Excess float64 `json:"excess,omitempty"`
+}
+
+type JsonResourceStorage struct {
+	StoredEnergy float64 `json:"storedEnergy"`
+	MaxEnergy    float64 `json:"maxEnergy"`
+	MaxMass      float64 `json:"maxMass"`
+	StoredMass   float64 `json:"storedMass"`
+}
+
+type JsonResources struct {
+	MassIn    JsonResourceIn      `json:"massin"`
+	EnergyOut JsonResourceOut     `json:"energyout"`
+	Storage   JsonResourceStorage `json:"storage"`
+	EnergyIn  JsonResourceIn      `json:"energyin"`
+	MassOut   JsonResourceOut     `json:"massout"`
 }
 
 type JsonStatsEntry struct {
-	Type     string                `json:"type"`
-	Name     string                `json:"name"`
-	Faction  int                   `json:"faction"`
-	Defeated float32               `json:"defeated"`
-	General  JsonStatsEntryGeneral `json:"general"`
+	Type       string                        `json:"type"`
+	Name       string                        `json:"name"`
+	Faction    int                           `json:"faction"`
+	Defeated   float64                       `json:"defeated"`
+	General    JsonStatsEntryGeneral         `json:"general"`
+	Units      map[string]JsonUnitCounters   `json:"units"`
+	Blueprints map[string]JsonBlueprintStats `json:"blueprints"`
+	Resources  JsonResources                 `json:"resources"`
 }
 
 type JsonStatsData struct {
@@ -27,15 +81,17 @@ type JsonStatsData struct {
 }
 
 type JsonStatsMessage struct {
-	Data JsonStatsData
+	Raw json.RawMessage
 }
 
 func NewJsonStatsMessage(
 	data JsonStatsData,
-) Message {
-	return &JsonStatsMessage{
-		Data: data,
+) (error, Message) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal JsonStatsMessage: %v", err), nil
 	}
+	return nil, &JsonStatsMessage{Raw: b}
 }
 
 func (m *JsonStatsMessage) GetCommand() string {
@@ -43,16 +99,11 @@ func (m *JsonStatsMessage) GetCommand() string {
 }
 
 func (m *JsonStatsMessage) GetArgs() []interface{} {
-	data, err := json.Marshal(m.Data)
-	if err != nil {
-		applog.Error("Failed to marshal JsonStatsMessage", zap.Error(err))
-		return []interface{}{
-			"{}",
-		}
+	if len(m.Raw) == 0 {
+		return []interface{}{"{}"}
 	}
-
 	return []interface{}{
-		string(data),
+		string(m.Raw),
 	}
 }
 
@@ -63,13 +114,34 @@ func (m *JsonStatsMessage) Build(args []interface{}) (Message, error) {
 		return m, fmt.Errorf("not enough arguments to parse (%d < %d)", len(args), jsonStatsMessageArgs)
 	}
 
-	m.Data = JsonStatsData{}
+	switch v := args[0].(type) {
+	case string:
+		m.Raw = json.RawMessage(v)
+	case []byte:
+		m.Raw = v
+	default:
+		return nil, fmt.Errorf("unexpected arg[0] type %T for JsonStatsMessage", v)
+	}
+	return m, nil
+}
 
-	stringData := args[0].(string)
-	err := json.Unmarshal([]byte(stringData), &m.Data)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse json stats message: %w", err)
+func (m *JsonStatsMessage) GetData() (JsonStatsData, error) {
+	var out JsonStatsData
+	if len(m.Raw) == 0 {
+		return out, nil
 	}
 
-	return m, nil
+	if err := json.Unmarshal(m.Raw, &out); err == nil {
+		return out, nil
+	}
+
+	norm, err := util.NormalizeJSONKeysToLower(m.Raw)
+	if err != nil {
+		applog.Warn("Getting JsonStatsMessage data failed at NormalizeJSONKeysToLower", zap.Error(err))
+		return out, json.Unmarshal(m.Raw, &out)
+	}
+	if err = json.Unmarshal(norm, &out); err != nil {
+		return out, err
+	}
+	return out, nil
 }

--- a/util/json.go
+++ b/util/json.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func NormalizeJSONKeysToLower(b []byte) ([]byte, error) {
+	var v any
+	if err := json.Unmarshal(b, &v); err != nil {
+		return nil, err
+	}
+	lower := lowercaseKeys(v)
+	return json.Marshal(lower)
+}
+
+func lowercaseKeys(v any) any {
+	switch x := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(x))
+		for k, val := range x {
+			out[strings.ToLower(k)] = lowercaseKeys(val)
+		}
+		return out
+	case []any:
+		for i := range x {
+			x[i] = lowercaseKeys(x[i])
+		}
+		return x
+	default:
+		return v
+	}
+}

--- a/webrtc/peer_manager.go
+++ b/webrtc/peer_manager.go
@@ -506,3 +506,9 @@ func (p *PeerManager) HandleGameDisconnected() {
 		applog.Error("Failed to send closing event to icebreaker", zap.Error(err))
 	}
 }
+
+func (p *PeerManager) HandleGameEnded() {
+	for _, peer := range p.peers {
+		peer.Disable()
+	}
+}


### PR DESCRIPTION
Made it so JSON will always read directly as string and if we need, we can get a structured view by calling `GetData()` of a message.
Should resolve issues like below reported by **speed2**:
```
{"level":"error","time":"2025-10-21T20:54:10Z","caller":"gpgnet/message.go:85","msg":"Failed to build GPG-Net message","localUserId":21916,"localGameId":561,"command":"JsonStats","error":"failed to parse json stats message: json: cannot unmarshal number 100.079998779297 into Go struct field JsonStatsEntryGeneral.stats.general.currentunits of type uint16"}
```
Also removed `disabledChannel` as we're not using it anyway.