### PR TITLE
Stop adapter when launcher disconnects

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -62,8 +62,8 @@ func (a *Adapter) Start() error {
 	go func() {
 		backoff := time.Second
 		for {
-			if err = a.icebreakerClient.Listen(iceBreakerEventChannel); err != nil {
-				applog.Error("Could not start listening ICE-Breaker API (server-side) events", zap.Error(err))
+			if listenErr := a.icebreakerClient.Listen(iceBreakerEventChannel); listenErr != nil {
+				applog.Error("Could not start listening ICE-Breaker API (server-side) events", zap.Error(listenErr))
 			}
 			select {
 			case <-a.ctx.Done():
@@ -157,17 +157,17 @@ func (a *Adapter) Start() error {
 
 	// Start the GPG-Net control server that acts like a primary bridge between game and this network adapter.
 	go func() {
-		if err = gpgNetServer.Listen(a.gpgNetFromGame, a.gpgNetToGame); err != nil {
-			applog.Error("Failed to start listening GPG-Net control server connections", zap.Error(err))
+		if listenErr := gpgNetServer.Listen(a.gpgNetFromGame, a.gpgNetToGame); listenErr != nil {
+			applog.Error("Failed to start listening GPG-Net control server connections", zap.Error(listenErr))
 		}
 	}()
 
 	// Start the GPG-Net client that will proxy data from game to FAF-Client.
 	go func() {
-		if err = gpgNetClient.Connect(a.gpgNetToFafClient, a.gpgNetFromFafClient); err != nil {
-			applog.Error("Failed to start listening GPG-Net client proxy connections", zap.Error(err))
-			a.cancel()
+		if connectErr := gpgNetClient.Connect(a.gpgNetToFafClient, a.gpgNetFromFafClient); connectErr != nil {
+			applog.Error("Failed to start listening GPG-Net client proxy connections", zap.Error(connectErr))
 		}
+		a.cancel()
 	}()
 
 	peerManager.Start()

--- a/adapter/adapter_test.go
+++ b/adapter/adapter_test.go
@@ -1,0 +1,124 @@
+package adapter
+
+import (
+	"context"
+	"faf-pioneer/applog"
+	"faf-pioneer/launcher"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAdapterStopsWhenLauncherDisconnects(t *testing.T) {
+	if err := applog.Initialize(1, 1, 0, t.TempDir()); err != nil {
+		t.Fatalf("failed to initialize logging: %v", err)
+	}
+	t.Cleanup(applog.Shutdown)
+
+	icebreaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/session/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"jwt":"session-token"}`)
+		case "/session/game/1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"id":"1","forceRelay":false,"servers":[]}`)
+		case "/session/game/1/events":
+			w.Header().Set("Content-Type", "text/event-stream")
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+				return
+			}
+			flusher.Flush()
+
+			ticker := time.NewTicker(10 * time.Millisecond)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-r.Context().Done():
+					return
+				case <-ticker.C:
+					_, _ = fmt.Fprint(w, ": keepalive\n\n")
+					flusher.Flush()
+				}
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer icebreaker.Close()
+
+	launcherListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen for adapter: %v", err)
+	}
+	defer launcherListener.Close()
+
+	gamePort := freeTCPPort(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	instance := New(ctx, cancel, &launcher.Info{
+		UserId:           1,
+		UserName:         "test-user",
+		GameId:           1,
+		AccessToken:      "access-token",
+		ApiRoot:          icebreaker.URL,
+		GpgNetPort:       gamePort,
+		GpgNetClientPort: uint(launcherListener.Addr().(*net.TCPAddr).Port),
+	})
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- instance.Start()
+	}()
+
+	launcherConnection, err := launcherListener.Accept()
+	if err != nil {
+		t.Fatalf("adapter did not connect to launcher: %v", err)
+	}
+
+	select {
+	case startErr := <-startDone:
+		_ = launcherConnection.Close()
+		t.Fatalf("adapter stopped before launcher disconnected: %v", startErr)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err = launcherConnection.Close(); err != nil {
+		t.Fatalf("failed to close launcher connection: %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("adapter context was not canceled after launcher disconnected")
+	}
+
+	select {
+	case startErr := <-startDone:
+		if startErr != nil {
+			t.Fatalf("adapter returned an error after launcher disconnected: %v", startErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("adapter did not stop after launcher disconnected")
+	}
+}
+
+func freeTCPPort(t *testing.T) uint {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to reserve game port: %v", err)
+	}
+	port := uint(listener.Addr().(*net.TCPAddr).Port)
+	if err = listener.Close(); err != nil {
+		t.Fatalf("failed to release game port: %v", err)
+	}
+	return port
+}

--- a/faf/gpgnet_client.go
+++ b/faf/gpgnet_client.go
@@ -74,6 +74,7 @@ func (s *GpgNetClient) Connect(toFafClientChannel chan gpgnet.Message, fromFafCl
 	go s.handleFromClient(faStreamReader)
 	go s.handleToClient(faStreamWriter)
 
+	<-s.ctx.Done()
 	return nil
 }
 

--- a/faf/gpgnet_client_test.go
+++ b/faf/gpgnet_client_test.go
@@ -1,0 +1,68 @@
+package faf
+
+import (
+	"context"
+	"faf-pioneer/applog"
+	"faf-pioneer/gpgnet"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestGpgNetClientConnectWaitsForDisconnect(t *testing.T) {
+	if err := applog.Initialize(1, 1, 0, t.TempDir()); err != nil {
+		t.Fatalf("failed to initialize logging: %v", err)
+	}
+	t.Cleanup(applog.Shutdown)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	defer listener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+
+	port := uint(listener.Addr().(*net.TCPAddr).Port)
+	client := NewGpgNetClient(ctx, port)
+	connectDone := make(chan error, 1)
+	go func() {
+		connectDone <- client.Connect(make(chan gpgnet.Message), make(chan gpgnet.Message))
+	}()
+
+	var conn net.Conn
+	select {
+	case conn = <-accepted:
+		defer conn.Close()
+	case <-time.After(time.Second):
+		t.Fatal("client did not connect")
+	}
+
+	select {
+	case connectErr := <-connectDone:
+		t.Fatalf("Connect returned before the launcher disconnected: %v", connectErr)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	if err = conn.Close(); err != nil {
+		t.Fatalf("failed to close launcher connection: %v", err)
+	}
+
+	select {
+	case connectErr := <-connectDone:
+		if connectErr != nil {
+			t.Fatalf("Connect returned an error after disconnect: %v", connectErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Connect did not return after the launcher disconnected")
+	}
+}


### PR DESCRIPTION
## Summary

- keep the GPG-Net client proxy alive for the launcher connection lifetime
- stop the adapter when the launcher disconnects
- keep startup goroutine errors local instead of sharing the outer error variable

## Why

The game-side GPG-Net connection already stops Pioneer when the game exits. If the game never connects and the launcher closes its socket, `GpgNetClient.Connect` has already returned, so only its child context is canceled. Pioneer then keeps running and retrying Icebreaker indefinitely.

## Validation

- regression tests fail on `main` and pass with this change
- black-box Windows check: `main` stayed alive after launcher disconnect; the patched executable exited normally
- `go test -race ./adapter ./faf`
- `go test ./adapter ./faf -count=20` on Windows
- `go vet ./adapter ./faf`
- `faf-adapter` builds for Windows, Linux, and macOS on amd64

Repository-wide `go test ./...` still hits the existing `applog` `TestNoRecursiveLogging_Fallback` failure, reproduced on unchanged `main`. Repository-wide `go vet ./...` also reports existing findings in `applog` and `test`; both affected packages pass vet.