### PR TITLE
Reset SSE reconnect backoff after successful connections

### DIFF
--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -62,7 +62,11 @@ func (a *Adapter) Start() error {
 	go func() {
 		backoff := time.Second
 		for {
-			if listenErr := a.icebreakerClient.Listen(iceBreakerEventChannel); listenErr != nil {
+			connected, listenErr := a.icebreakerClient.Listen(iceBreakerEventChannel)
+			if connected {
+				backoff = time.Second
+			}
+			if listenErr != nil {
 				applog.Error("Could not start listening ICE-Breaker API (server-side) events", zap.Error(listenErr))
 			}
 			select {

--- a/adapter/adapter.go
+++ b/adapter/adapter.go
@@ -2,6 +2,7 @@ package adapter
 
 import (
 	"context"
+	"errors"
 	"faf-pioneer/applog"
 	"faf-pioneer/faf"
 	"faf-pioneer/gpgnet"
@@ -16,29 +17,33 @@ import (
 	"time"
 )
 
+const defaultStableConnectionThreshold = 30 * time.Second
+
 type Adapter struct {
-	gpgNetFromGame      chan gpgnet.Message
-	gpgNetToGame        chan gpgnet.Message
-	gpgNetToFafClient   chan gpgnet.Message
-	gpgNetFromFafClient chan gpgnet.Message
-	gameDataToGame      chan *[]byte
-	icebreakerClient    *icebreaker.Client
-	ctx                 context.Context
-	cancel              context.CancelFunc
-	launcherInfo        *launcher.Info
+	gpgNetFromGame            chan gpgnet.Message
+	gpgNetToGame              chan gpgnet.Message
+	gpgNetToFafClient         chan gpgnet.Message
+	gpgNetFromFafClient       chan gpgnet.Message
+	gameDataToGame            chan *[]byte
+	icebreakerClient          *icebreaker.Client
+	ctx                       context.Context
+	cancel                    context.CancelFunc
+	launcherInfo              *launcher.Info
+	stableConnectionThreshold time.Duration
 }
 
 func New(ctx context.Context, cancel context.CancelFunc, info *launcher.Info) *Adapter {
 	instance := &Adapter{
-		ctx:                 ctx,
-		cancel:              cancel,
-		launcherInfo:        info,
-		gpgNetFromGame:      make(chan gpgnet.Message),
-		gpgNetToGame:        make(chan gpgnet.Message),
-		gpgNetToFafClient:   make(chan gpgnet.Message),
-		gpgNetFromFafClient: make(chan gpgnet.Message),
-		gameDataToGame:      make(chan *[]byte),
-		icebreakerClient:    icebreaker.NewClient(ctx, info.ApiRoot, info.GameId, info.AccessToken),
+		ctx:                       ctx,
+		cancel:                    cancel,
+		launcherInfo:              info,
+		gpgNetFromGame:            make(chan gpgnet.Message),
+		gpgNetToGame:              make(chan gpgnet.Message),
+		gpgNetToFafClient:         make(chan gpgnet.Message),
+		gpgNetFromFafClient:       make(chan gpgnet.Message),
+		gameDataToGame:            make(chan *[]byte),
+		icebreakerClient:          icebreaker.NewClient(ctx, info.ApiRoot, info.GameId, info.AccessToken),
+		stableConnectionThreshold: defaultStableConnectionThreshold,
 	}
 
 	return instance
@@ -62,11 +67,12 @@ func (a *Adapter) Start() error {
 	go func() {
 		backoff := time.Second
 		for {
+			listenStartedAt := time.Now()
 			connected, listenErr := a.icebreakerClient.Listen(iceBreakerEventChannel)
-			if connected {
+			if connected && time.Since(listenStartedAt) >= a.stableConnectionThreshold {
 				backoff = time.Second
 			}
-			if listenErr != nil {
+			if listenErr != nil && !errors.Is(listenErr, context.Canceled) {
 				applog.Error("Could not start listening ICE-Breaker API (server-side) events", zap.Error(listenErr))
 			}
 			select {

--- a/adapter/adapter_test.go
+++ b/adapter/adapter_test.go
@@ -8,16 +8,34 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 	"time"
 )
 
-func TestAdapterStopsWhenLauncherDisconnects(t *testing.T) {
-	if err := applog.Initialize(1, 1, 0, t.TempDir()); err != nil {
-		t.Fatalf("failed to initialize logging: %v", err)
+func TestMain(m *testing.M) {
+	logDir, err := os.MkdirTemp("", "faf-pioneer-adapter-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
+		os.Exit(1)
 	}
-	t.Cleanup(applog.Shutdown)
 
+	if err = applog.Initialize(1, 1, 0, logDir); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to initialize logging: %v\n", err)
+		_ = os.RemoveAll(logDir)
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+	applog.Shutdown()
+	if err = os.RemoveAll(logDir); err != nil && exitCode == 0 {
+		fmt.Fprintf(os.Stderr, "failed to remove log directory: %v\n", err)
+		exitCode = 1
+	}
+	os.Exit(exitCode)
+}
+
+func TestAdapterStopsWhenLauncherDisconnects(t *testing.T) {
 	icebreaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/session/token":
@@ -106,6 +124,84 @@ func TestAdapterStopsWhenLauncherDisconnects(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("adapter did not stop after launcher disconnected")
+	}
+}
+
+func TestAdapterResetsEventBackoffAfterSuccessfulConnection(t *testing.T) {
+	eventAttempts := make(chan time.Time, 3)
+	icebreaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/session/token":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"jwt":"session-token"}`)
+		case "/session/game/1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprint(w, `{"id":"1","forceRelay":false,"servers":[]}`)
+		case "/session/game/1/events":
+			eventAttempts <- time.Now()
+			w.Header().Set("Content-Type", "text/event-stream")
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer icebreaker.Close()
+
+	launcherListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen for adapter: %v", err)
+	}
+	defer launcherListener.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	instance := New(ctx, cancel, &launcher.Info{
+		UserId:           1,
+		UserName:         "test-user",
+		GameId:           1,
+		AccessToken:      "access-token",
+		ApiRoot:          icebreaker.URL,
+		GpgNetPort:       freeTCPPort(t),
+		GpgNetClientPort: uint(launcherListener.Addr().(*net.TCPAddr).Port),
+	})
+
+	startDone := make(chan error, 1)
+	go func() {
+		startDone <- instance.Start()
+	}()
+
+	launcherConnection, err := launcherListener.Accept()
+	if err != nil {
+		t.Fatalf("adapter did not connect to launcher: %v", err)
+	}
+	defer launcherConnection.Close()
+
+	attempts := make([]time.Time, 3)
+	for i := range attempts {
+		select {
+		case attempts[i] = <-eventAttempts:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for event connection attempt %d", i+1)
+		}
+	}
+
+	firstDelay := attempts[1].Sub(attempts[0])
+	secondDelay := attempts[2].Sub(attempts[1])
+	if secondDelay >= firstDelay*3/2 {
+		t.Fatalf("event reconnect backoff was not reset after a successful connection: first delay %v, second delay %v", firstDelay, secondDelay)
+	}
+
+	cancel()
+	select {
+	case startErr := <-startDone:
+		if startErr != nil {
+			t.Fatalf("adapter returned an error during shutdown: %v", startErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("adapter did not stop after cancellation")
 	}
 }
 

--- a/adapter/adapter_test.go
+++ b/adapter/adapter_test.go
@@ -127,7 +127,22 @@ func TestAdapterStopsWhenLauncherDisconnects(t *testing.T) {
 	}
 }
 
-func TestAdapterResetsEventBackoffAfterSuccessfulConnection(t *testing.T) {
+func TestAdapterBacksOffAfterShortEventConnections(t *testing.T) {
+	testAdapterEventReconnectBackoff(t, 0, time.Minute, false)
+}
+
+func TestAdapterResetsEventBackoffAfterStableConnection(t *testing.T) {
+	testAdapterEventReconnectBackoff(t, 50*time.Millisecond, 25*time.Millisecond, true)
+}
+
+func testAdapterEventReconnectBackoff(
+	t *testing.T,
+	connectionDuration time.Duration,
+	stableConnectionThreshold time.Duration,
+	wantReset bool,
+) {
+	t.Helper()
+
 	eventAttempts := make(chan time.Time, 3)
 	icebreaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -143,6 +158,7 @@ func TestAdapterResetsEventBackoffAfterSuccessfulConnection(t *testing.T) {
 			if flusher, ok := w.(http.Flusher); ok {
 				flusher.Flush()
 			}
+			time.Sleep(connectionDuration)
 		default:
 			http.NotFound(w, r)
 		}
@@ -167,6 +183,7 @@ func TestAdapterResetsEventBackoffAfterSuccessfulConnection(t *testing.T) {
 		GpgNetPort:       freeTCPPort(t),
 		GpgNetClientPort: uint(launcherListener.Addr().(*net.TCPAddr).Port),
 	})
+	instance.stableConnectionThreshold = stableConnectionThreshold
 
 	startDone := make(chan error, 1)
 	go func() {
@@ -190,8 +207,11 @@ func TestAdapterResetsEventBackoffAfterSuccessfulConnection(t *testing.T) {
 
 	firstDelay := attempts[1].Sub(attempts[0])
 	secondDelay := attempts[2].Sub(attempts[1])
-	if secondDelay >= firstDelay*3/2 {
-		t.Fatalf("event reconnect backoff was not reset after a successful connection: first delay %v, second delay %v", firstDelay, secondDelay)
+	if wantReset && secondDelay >= firstDelay*3/2 {
+		t.Fatalf("event reconnect backoff was not reset after a stable connection: first delay %v, second delay %v", firstDelay, secondDelay)
+	}
+	if !wantReset && secondDelay < firstDelay*3/2 {
+		t.Fatalf("event reconnect backoff was reset after a short connection: first delay %v, second delay %v", firstDelay, secondDelay)
 	}
 
 	cancel()

--- a/icebreaker/icebreaker.go
+++ b/icebreaker/icebreaker.go
@@ -7,6 +7,7 @@ import (
 	"faf-pioneer/util"
 	"fmt"
 	"go.uber.org/zap"
+	"net/http"
 	"resty.dev/v3"
 )
 
@@ -184,19 +185,23 @@ func (c *Client) SendEvent(msg EventMessage) error {
 	return nil
 }
 
-func (c *Client) Listen(channel chan EventMessage) error {
+func (c *Client) Listen(channel chan EventMessage) (bool, error) {
 	err := c.withSessionToken()
 
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	url := fmt.Sprintf("%s/session/game/%d/events", c.apiRoot, c.gameId)
+	connected := false
 
 	eventSource := resty.NewSSESource().
 		SetURL(url).
 		SetContext(c.ctx).
 		SetHeader("Authorization", fmt.Sprintf("Bearer %s", c.sessionToken)).
+		OnOpen(func(_ string, _ http.Header) {
+			connected = true
+		}).
 		OnMessage(func(message any) {
 			restyEvent, ok := message.(*resty.SSE)
 			if !ok {
@@ -260,8 +265,8 @@ func (c *Client) Listen(channel chan EventMessage) error {
 	err = eventSource.Get()
 
 	if err != nil {
-		return fmt.Errorf("could not attach to message event endpoint: %s", err)
+		return connected, fmt.Errorf("could not attach to message event endpoint: %s", err)
 	}
 
-	return nil
+	return connected, nil
 }

--- a/icebreaker/icebreaker.go
+++ b/icebreaker/icebreaker.go
@@ -257,15 +257,20 @@ func (c *Client) Listen(channel chan EventMessage) (bool, error) {
 
 	applog.Info("Listening for ICE-Breaker API (server-side) events", zap.String("url", url))
 
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		<-c.ctx.Done()
-		eventSource.Close()
+		select {
+		case <-c.ctx.Done():
+			eventSource.Close()
+		case <-done:
+		}
 	}()
 
 	err = eventSource.Get()
 
 	if err != nil {
-		return connected, fmt.Errorf("could not attach to message event endpoint: %s", err)
+		return connected, fmt.Errorf("could not attach to message event endpoint: %w", err)
 	}
 
 	return connected, nil

--- a/icebreaker/icebreaker_test.go
+++ b/icebreaker/icebreaker_test.go
@@ -1,0 +1,33 @@
+package icebreaker
+
+import (
+	"context"
+	"faf-pioneer/applog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListenReportsUnauthorizedResponseAsNotConnected(t *testing.T) {
+	if err := applog.Initialize(1, 1, 0, t.TempDir()); err != nil {
+		t.Fatalf("failed to initialize logging: %v", err)
+	}
+	t.Cleanup(applog.Shutdown)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewClient(context.Background(), server.URL, 1, "access-token")
+	client.sessionToken = "session-token"
+
+	connected, err := client.Listen(make(chan EventMessage))
+	if connected {
+		t.Fatal("rejected event connection was reported as connected")
+	}
+	if err == nil || !strings.Contains(err.Error(), "401 Unauthorized") {
+		t.Fatalf("expected 401 connection error, got %v", err)
+	}
+}

--- a/icebreaker/icebreaker_test.go
+++ b/icebreaker/icebreaker_test.go
@@ -2,11 +2,14 @@ package icebreaker
 
 import (
 	"context"
+	"errors"
 	"faf-pioneer/applog"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestListenReportsUnauthorizedResponseAsNotConnected(t *testing.T) {
@@ -30,4 +33,88 @@ func TestListenReportsUnauthorizedResponseAsNotConnected(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "401 Unauthorized") {
 		t.Fatalf("expected 401 connection error, got %v", err)
 	}
+}
+
+func TestListenDoesNotLeakContextWatchersAfterReconnects(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.(http.Flusher).Flush()
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := NewClient(ctx, server.URL, 1, "access-token")
+	client.sessionToken = "session-token"
+
+	watchersBefore := countListenContextWatchers()
+	for range 10 {
+		_, err := client.Listen(make(chan EventMessage))
+		if err == nil {
+			t.Fatal("expected the closed event stream to return an error")
+		}
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for countListenContextWatchers() > watchersBefore && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if watchersAfter := countListenContextWatchers(); watchersAfter > watchersBefore {
+		t.Fatalf("event reconnects leaked %d context watcher goroutines", watchersAfter-watchersBefore)
+	}
+}
+
+func TestListenPreservesContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = w.Write([]byte("data: {\"eventType\":\"connected\",\"gameId\":1,\"senderId\":2}\n\n"))
+		flusher.Flush()
+
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				_, _ = w.Write([]byte(": keepalive\n\n"))
+				flusher.Flush()
+			}
+		}
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	client := NewClient(ctx, server.URL, 1, "access-token")
+	client.sessionToken = "session-token"
+	events := make(chan EventMessage, 1)
+
+	listenDone := make(chan error, 1)
+	go func() {
+		_, err := client.Listen(events)
+		listenDone <- err
+	}()
+
+	select {
+	case <-events:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for the event stream to deliver a message")
+	}
+	cancel()
+
+	select {
+	case err := <-listenDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context cancellation, got %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("event listener did not stop after context cancellation")
+	}
+}
+
+func countListenContextWatchers() int {
+	stack := make([]byte, 1<<20)
+	length := runtime.Stack(stack, true)
+	return strings.Count(string(stack[:length]), "faf-pioneer/icebreaker.(*Client).Listen.func")
 }


### PR DESCRIPTION
## Summary

- reset SSE reconnect backoff only after a stream remains open for 30 seconds
- retain exponential backoff across rejected and short-lived HTTP 200 connections
- stop each per-listen cancellation watcher when `Listen` returns
- preserve context cancellation and avoid error-level noise on normal shutdown
- cover rejected, short-lived, stable, canceled, and repeated connections

## Why

While tracing [faf-icebreaker PR #166](https://github.com/FAForever/faf-icebreaker/pull/166), Pioneer logs showed successful SSE streams followed by retry delays that continued growing through 1, 2, 4, 8, 16, and 32 seconds.

Resetting on Resty's `OnOpen` callback alone is too weak because it only proves that the server returned HTTP 200. A server that immediately closes every stream would otherwise pin retries at one request per second. The 30-second stability threshold recognizes a useful recovery without requiring event traffic from a valid but idle SSE stream.

## Validation

- the short-connection regression failed before the correction with delays of 1.001s and 1.001s
- short connections now retain exponential backoff; stable connections reset it
- ten immediate reconnects no longer leave ten cancellation watchers behind
- reconnect tests pass five consecutive times; listener tests pass ten consecutive times
- `go test ./adapter ./icebreaker`
- `go test -race ./adapter ./icebreaker` on Linux
- `go vet ./adapter ./icebreaker`
- `go mod tidy` produces no dependency changes
- `faf-adapter` builds for Windows, Linux, and macOS on amd64

Repository-wide `go test ./...` still hits the existing `applog` `TestNoRecursiveLogging_Fallback` failure, reproduced on unchanged `main`. Repository-wide `go vet ./...` likewise reports the existing findings in `applog` and `test`.